### PR TITLE
Add dependency version checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem install metadata-json-lint
 In your shell, with the `metadata-json-lint` and the path of your `metadata.json` file
 
 ```shell
-metadata-json-lint /path/too/metadata.json
+metadata-json-lint /path/to/metadata.json
 ```
 
 ### Rake task
@@ -36,6 +36,7 @@ rake metadata_lint
 ### Options
 
 ```
+--[no-]strict-dependencies   Fail on open-ended module version dependencies
 --[no-]strict-license        Don't fail on strict license check
 --[no-]fail-on-warnings      Fail on any warnings
 ```

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -8,11 +8,12 @@ Gem::Specification.new do |s|
   s.email       = 'nibz@spencerkrum.com'
   s.files       = ['bin/metadata-json-lint', 'lib/metadata_json_lint.rb', 'lib/metadata-json-lint/rake_task.rb']
   s.executables << 'metadata-json-lint'
-  s.homepage    = 'http://github.com/nibalizer/metadata-json-lint'
+  s.homepage    = 'http://github.com/voxpupuli/metadata-json-lint'
   s.license     = 'Apache-2.0'
 
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
   s.add_runtime_dependency 'json'
+  s.add_runtime_dependency 'semantic_puppet', '>= 0.1.2', '< 1.0.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop'
 end

--- a/tests/missing_version_requirement/Rakefile
+++ b/tests/missing_version_requirement/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/missing_version_requirement/metadata.json
+++ b/tests/missing_version_requirement/metadata.json
@@ -1,0 +1,31 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 3.4.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": [
+    { "name": "puppetlabs/stdlib" }
+  ]
+}

--- a/tests/mixed_version_syntax/Rakefile
+++ b/tests/mixed_version_syntax/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/mixed_version_syntax/metadata.json
+++ b/tests/mixed_version_syntax/metadata.json
@@ -1,0 +1,34 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 3.4.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 3.2.x"
+    }
+  ]
+}

--- a/tests/no_dependencies/Rakefile
+++ b/tests/no_dependencies/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/no_dependencies/metadata.json
+++ b/tests/no_dependencies/metadata.json
@@ -66,30 +66,5 @@
       "version_requirement": "3.x"
     }
   ],
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": "1.2.3"
-    },
-    {
-      "name": "puppetlabs/apt",
-      "version_requirement": "< 1.2.3"
-    },
-    {
-      "name": "puppetlabs/puppetdb",
-      "version_requirement": "<= 1.2.3"
-    },
-    {
-      "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
-      "name": "puppetlabs/rabbitmq",
-      "version_requirement": "1.x"
-    },
-    {
-      "name": "puppetlabs/motd",
-      "version_requirement": "1.2.x"
-    }
-  ]
+  "dependencies": []
 }

--- a/tests/open_ended_dependency/Rakefile
+++ b/tests/open_ended_dependency/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/open_ended_dependency/metadata.json
+++ b/tests/open_ended_dependency/metadata.json
@@ -1,0 +1,34 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 3.4.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 3.2.0"
+    }
+  ]
+}

--- a/tests/proprietary/metadata.json
+++ b/tests/proprietary/metadata.json
@@ -72,10 +72,6 @@
       "version_requirement": "4.x"
     },
     {
-      "name": "puppetlabs/firewall",
-      "version_requirement": ">= 0.0.4"
-    },
-    {
       "name": "puppetlabs/apt",
       "version_requirement": ">=1.1.0 <2.0.0"
     },

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -50,6 +50,18 @@ test "bad_license" $FAILURE
 # Run a broken one, expect FAILURE
 test "long_summary" $FAILURE
 
+# Run a broken one, expect FAILURE
+test "mixed_version_syntax" $FAILURE
+
+# Run one with empty dependencies array, expect SUCCESS
+test "no_dependencies" $SUCCESS
+
+# Run one with open ended dependency and --no-strict-dependency, expect SUCCESS
+test "open_ended_dependency" $SUCCESS
+
+# Run one with missing version_requirement and --no-strict-dependency, expect SUCCESS
+test "missing_version_requirement" $SUCCESS
+
 # Run test for "proprietary"-licensed modules, expect SUCCESS
 test "proprietary" $SUCCESS
 
@@ -71,7 +83,25 @@ if [ $RESULT -ne $SUCCESS ]; then
 fi
 cd ..
 
-# Run a broken one, expect SUCCESS
+# Run one with open ended dependency and --strict-dependency, expect FAILURE
+cd open_ended_dependency
+../../bin/metadata-json-lint --strict-dependencies metadata.json >/dev/null 2>&1
+RESULT=$?
+if [ $RESULT -ne $FAILURE ]; then
+    echo "Failing Test with open ended dependency"
+fi
+cd ..
+
+# Run one with missing version_requirement and --strict-dependency, expect FAILURE
+cd missing_version_requirement
+../../bin/metadata-json-lint --strict-dependencies metadata.json >/dev/null 2>&1
+RESULT=$?
+if [ $RESULT -ne $FAILURE ]; then
+    echo "Failing Test with missing version_requirement"
+fi
+cd ..
+
+# Run a broken one, expect FAILURE
 # Testing on no file given
 ../bin/metadata-json-lint >/dev/null 2>&1
 RESULT=$?


### PR DESCRIPTION
A hopefully improved version of #9. Closes #24.

Changes compared to #9:
* Uses the new [semantic_puppet](https://rubygems.org/gems/semantic_puppet) gem for parsing and validation of the version_requirement. This means validation code does not need to be maintained in this gem, and works around #10. If Puppet decides to change their validation rules, no action would be required here.
* Addresses the issues raised in #11, and tests for them. The only exception is that an empty version_requirement field (i.e. `"version_requirement": ""`) is treated as an error by semantic_puppet, so this continues to throw an error. But `"dependencies": []` will not throw an error, and `{ "name": "puppetlabs/stdlib" }` will be treated as an open ended dependency.
* Several additional tests

Issues with this PR:
* Rubocop issues failing the build. If #29 is merged it will solve the build errors.
* semantic_puppet may be too strict. This PR currently causes error state when semantic_puppet can't/won't parse the version dependency. This is probably the right behaviour, but might cause some short-term pain.
* semantic_puppet code is subject to change. Their README states

> Note that this is a 0 release version, and things can change. Expect that the version and version range code to stay relatively stable, but the module dependency code is expected to change.

If this holds true, there should be low risk of this code breaking due to changes in that gem, as it relies only on the version range code which should stay "relatively stable".