### PR TITLE
set explicit rvm so gem dependencies install

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,5 @@
 inherit_from: .rubocop_todo.yml
 
-# dealbreaker:
-Style/TrailingComma:
-  Enabled: false
-
 # we still support ruby 1.8
 Style/HashSyntax:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script:
   - bundle exec rubocop
   - cd tests && ./test.sh
 sudo: false
+rvm:
+  - 2.2
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
Newer versions of json gem require Ruby 2 or higher.

To run tests, either they must be run on Ruby 2 or higher, or the json gem needs to be pinned to a lower version in gemspec.