### PR TITLE
Rubocop tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,19 @@ inherit_from: .rubocop_todo.yml
 # we still support ruby 1.8
 Style/HashSyntax:
   Enabled: false
+
+#Metric cops are rarely useful
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,28 +12,6 @@ Lint/RescueException:
     - 'lib/metadata_json_lint.rb'
 
 # Offense count: 1
-Metrics/AbcSize:
-  Max: 48
-
-# Offense count: 1
-Metrics/CyclomaticComplexity:
-  Max: 13
-
-# Offense count: 5
-# Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
-  Max: 112
-
-# Offense count: 2
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 45
-
-# Offense count: 1
-Metrics/PerceivedComplexity:
-  Max: 14
-
-# Offense count: 1
 # Configuration parameters: Exclude.
 Style/Documentation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,15 +16,3 @@ Lint/RescueException:
 Style/Documentation:
   Exclude:
     - 'lib/metadata_json_lint.rb'
-
-# Offense count: 1
-# Configuration parameters: Exclude.
-Style/FileName:
-  Exclude:
-    - 'bin/metadata-json-lint'
-
-# Offense count: 1
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'lib/metadata_json_lint.rb'


### PR DESCRIPTION
- Disable the Metrics cops permanently - they're not useful
- Remove a couple of Style cops from the configuration that no longer flag errors