### PR TITLE
Do not require that the filename 'metadata.json' be passed.

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -15,7 +15,7 @@ module MetadataJsonLint
 
   def run
     OptionParser.new do |opts|
-      opts.banner = 'Usage: metadata-json-lint [options] metadata.json'
+      opts.banner = 'Usage: metadata-json-lint [options] [metadata.json]'
 
       opts.on('--[no-]strict-dependencies', 'Fail on open-ended module version dependencies') do |v|
         options[:strict_dependencies] = v
@@ -30,9 +30,17 @@ module MetadataJsonLint
       end
     end.parse!
 
-    abort('Error: Must provide a metadata.json file to parse') if ARGV[0].nil?
+    mj = if ARGV[0].nil?
+           if File.readable?('metadata.json')
+             'metadata.json'
+           else
+             abort('Error: metadata.json is not readable or does not exist.')
+           end
+         else
+           ARGV[0]
+         end
 
-    MetadataJsonLint.parse(ARGV.first)
+    MetadataJsonLint.parse(mj)
   end
   module_function :run
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -85,4 +85,13 @@ test "proprietary" $SUCCESS
 # Run without a metadata.json or Rakefile, expect FAILURE
 test "no_files" $FAILURE
 
+# Test running without specifying file to parse
+cd perfect
+bundle exec metadata-json-lint
+if [ $? -ne 0 ]; then
+    fail "Failing Test 'running without specifying metadata.json' (bin)"
+else
+    echo "Successful Test 'running without specifying metadata.json' (bin)"
+fi
+
 exit $STATUS


### PR DESCRIPTION
This tool is built to lint metadata.json, so the argument for the
filename should not be mandatory.