### PR TITLE
Update tests to expect specific output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 /.bundle
 /vendor
+tests/*/last_output

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -53,7 +53,11 @@ module MetadataJsonLint
     options = options().clone
     # Configuration from rake tasks
     yield options if block_given?
-    f = File.read(metadata)
+    begin
+      f = File.read(metadata)
+    rescue Exception => e
+      abort("Error: Unable to read metadata file: #{e.exception}")
+    end
 
     begin
       parsed = JSON.parse(f)

--- a/tests/bad_license/expected
+++ b/tests/bad_license/expected
@@ -1,0 +1,1 @@
+Warning: License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/

--- a/tests/broken/expected
+++ b/tests/broken/expected
@@ -1,0 +1,1 @@
+Error: Unable to parse metadata.json: 743: unexpected token at

--- a/tests/duplicate-dep/expected
+++ b/tests/duplicate-dep/expected
@@ -1,0 +1,1 @@
+Error: duplicate dependencies on puppetlabs/stdlib

--- a/tests/long_summary/expected
+++ b/tests/long_summary/expected
@@ -1,0 +1,1 @@
+Error: summary exceeds 144 characters in metadata.json

--- a/tests/long_summary/metadata.json
+++ b/tests/long_summary/metadata.json
@@ -2,11 +2,11 @@
   "name": "foo-bar",
   "version": "1.0.0",
   "author": "foo/bar",
-  "summary": "This is obviously a way way tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long"
+  "summary": "This is obviously a way way tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long",
   "license": "Apache-2.0",
-  "source": ""
-  "project_page": ""
-  "issues_url": ""
+  "source": "",
+  "project_page": "",
+  "issues_url": "",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",

--- a/tests/missing_version_requirement/expected
+++ b/tests/missing_version_requirement/expected
@@ -1,0 +1,1 @@
+Warning: Dependency puppetlabs/stdlib has an open ended dependency version requirement

--- a/tests/mixed_version_syntax/expected
+++ b/tests/mixed_version_syntax/expected
@@ -1,0 +1,1 @@
+Invalid 'version_requirement' field in metadata.json: Unparsable version range: ">= 3.2.x"

--- a/tests/multiple_problems/expected
+++ b/tests/multiple_problems/expected
@@ -1,0 +1,3 @@
+Error: Required field 'license' not found in metadata.json.
+Error: Required field 'summary' not found in metadata.json.
+Error: Deprecated field 'types' found in metadata.json.

--- a/tests/no_files/expected
+++ b/tests/no_files/expected
@@ -1,0 +1,1 @@
+Error: Unable to read metadata file: No such file or directory

--- a/tests/noname/expected
+++ b/tests/noname/expected
@@ -1,0 +1,1 @@
+Error: Required field 'name' not found in metadata.json.

--- a/tests/open_ended_dependency/expected
+++ b/tests/open_ended_dependency/expected
@@ -1,0 +1,1 @@
+Warning: Dependency puppetlabs/stdlib has an open ended dependency version requirement >= 3.2.0

--- a/tests/rake_global_options/expected
+++ b/tests/rake_global_options/expected
@@ -1,0 +1,1 @@
+Warning: License identifier invalid_license is not in the SPDX list: http://spdx.org/licenses/

--- a/tests/tags_no_array/expected
+++ b/tests/tags_no_array/expected
@@ -1,0 +1,1 @@
+Warning: Tags must be in an array. Currently it's a String.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -34,7 +34,8 @@ test_bin() {
   bundle exec metadata-json-lint $* metadata.json >last_output 2>&1
   RESULT=$?
   if [ $RESULT -ne $expect ]; then
-    fail "Failing Test (unexpected exit code) '${name}' (bin)"
+    fail "Failing Test '${name}' (unexpected exit code '${RESULT}' instead of '${expect}') (bin)"
+    echo "    Note: you can examine '${name}/last_output' for any output"
   else
     # If the test is not expected to succeed then it should match an expected output
     if [ $expect -eq $SUCCESS ]; then
@@ -44,13 +45,14 @@ test_bin() {
         if grep --quiet "`cat expected`" last_output; then
           echo "Successful Test '${name}' (bin)"
         else
-          fail "Failing Test (did not get expected output) '${name}' (bin)"
-          echo "Expected: '`cat expected`'"
-          echo "Actual: '`cat last_output`'"
+          fail "Failing Test '${name}' (did not get expected output) (bin)"
+          echo "    Comparing '${name}/expected' with '${name}/last_output':"
+          echo "        Expected: '`cat expected`'"
+          echo "        Actual: '`cat last_output`'"
         fi
       else
-        fail "Failing Test (expected output file ${name}/expected is missing) '${name}' (bin)"
-        echo "Actual output that needs tested: '`cat last_output`'"
+        fail "Failing Test '${name}' (expected output file ${name}/expected is missing) (bin)"
+        echo "    Actual output that needs tested ('${name}/last_output'): '`cat last_output`'"
       fi
     fi
   fi

--- a/tests/types/expected
+++ b/tests/types/expected
@@ -1,0 +1,1 @@
+Error: Deprecated field 'types' found in metadata.json.


### PR DESCRIPTION
Test cases that expect metadata-json-lint to return non-zero should also test that the output from
metadata-json-lint matches some expected output. Otherwise the test will pass if _any_ problem occurs.

This PR also contains a small change to exception handling (if metadata.json does not exist) and a fix to one of the existing tests (so that it will fail for the expected reason)