### PR TITLE
Release 1.1.0

### DIFF
--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -2,7 +2,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'metadata-json-lint'
-  s.version     = '1.0.0'
+  s.version     = '1.1.0'
   s.date        = Date.today.to_s
   s.summary     = 'metadata-json-lint /path/to/metadata.json'
   s.description = 'Utility to verify Puppet metadata.json files'


### PR DESCRIPTION
Draft release notes, which I'll add to GitHub releases when I tag it:

## Features
* Ensure module `tags` are correctly specified as an array (#44)
* Ensure `requirements` doesn't list the deprecated `pe` key (#46)
* Ensure `dependencies` aren't listed with `version_range` keys (#47)
* Support strictness configuration via Ruby API, for use in rake tasks definitions
* Show default strictness option values in `--help` output

## Bug fixes
* Fix unclear error message when metadata.json does not exist
* Fix gem publishing date
* Various test improvements, ensuring failures are caught accurately and precisely