### PR TITLE
Ensure "dependencies" is an array

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -135,6 +135,11 @@ module MetadataJsonLint
   module_function :invalid_requirements?
 
   def invalid_dependencies?(deps)
+    unless deps.is_a?(Array)
+      puts "Warning: Dependencies must be in an array. Currently it's a #{deps.class}."
+      error_state = true
+      return error_state
+    end
     error_state = false
     dep_names = []
     deps.each do |dep|

--- a/tests/dependencies_not_array/Rakefile
+++ b/tests/dependencies_not_array/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/dependencies_not_array/expected
+++ b/tests/dependencies_not_array/expected
@@ -1,0 +1,1 @@
+Warning: Dependencies must be in an array. Currently it's a String.

--- a/tests/dependencies_not_array/metadata.json
+++ b/tests/dependencies_not_array/metadata.json
@@ -1,0 +1,70 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 3.4.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": "string"
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -126,6 +126,9 @@ test "proprietary" $SUCCESS
 # Run without a metadata.json or Rakefile, expect FAILURE
 test "no_files" $FAILURE
 
+# Run a broken one, expect FAILURE
+test "dependencies_not_array" $FAILURE
+
 # Run with tags in an array in metadata.json, expect SUCCESS
 test "tags_with_array" $SUCCESS
 


### PR DESCRIPTION
A minor new check to ensure correct format of dependencies field.