### PR TITLE
Fix 'broken' test to not check for specific JSON error code

### DIFF
--- a/tests/broken/expected
+++ b/tests/broken/expected
@@ -1,1 +1,1 @@
-Error: Unable to parse metadata.json: 743: unexpected token at
+Error: Unable to parse metadata.json: [0-9]*: unexpected token at

--- a/tests/json_format/expected
+++ b/tests/json_format/expected
@@ -1,1 +1,1 @@
-"errors":[{"check":"license","msg":"License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/"}]
+"errors":\[{"check":"license","msg":"License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/"}\]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -42,7 +42,7 @@ test_bin() {
       echo "Successful Test '${name}' (bin)"
     else
       if [ -f expected ]; then
-        if grep -F --quiet -f expected last_output; then
+        if grep --quiet -f expected last_output; then
           echo "Successful Test '${name}' (bin)"
         else
           fail "Failing Test '${name}' (did not get expected output) (bin)"


### PR DESCRIPTION
The integers in the JSON gem's error messages are source code line
numbers, which change between releases (e.g. 2.0.4 to 2.1.0).

---

Please note that the "mixed_version_syntax" test will still fail (see https://github.com/puppetlabs/semantic_puppet/pull/24), but the test named "broken" should now pass.