### PR TITLE
Replace conditionals/custom checks with a JSON schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,10 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*_spec.rb
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/lib/metadata-json-lint/schema.rb
+++ b/lib/metadata-json-lint/schema.rb
@@ -1,0 +1,150 @@
+require 'json-schema'
+
+module MetadataJsonLint
+  # Provides validation of metadata.json against a JSON schema document
+  # maintained in this class. Provides a good first pass over the metadata with
+  # type checking and basic format/length validations.
+  #
+  # rubocop:disable Metrics/ClassLength # schema data structure is quite large
+  class Schema
+    # Based on https://docs.puppet.com/puppet/latest/modules_metadata.html
+    #
+    # rubocop:disable Style/TrailingCommaInLiteral # easier to modify individual lines
+    def schema
+      {
+        '$schema' => 'http://json-schema.org/draft-04/schema#',
+        'properties' => {
+          'author' => {
+            'type' => 'string',
+          },
+          'data_provider' => {
+            'type' => %w[null string],
+          },
+          'dependencies' => {
+            'type' => 'array',
+            'items' => {
+              'properties' => {
+                'name' => {
+                  'type' => 'string',
+                  'pattern' => '^\w+[/-][a-z][a-z0-9_]*$',
+                },
+                'version_requirement' => {
+                  'type' => 'string',
+                },
+              },
+              'required' => %w[
+                name
+              ],
+            },
+          },
+          'description' => {
+            'type' => 'string',
+          },
+          'issues_url' => {
+            'type' => 'string',
+            'format' => 'uri',
+          },
+          'license' => {
+            'type' => 'string',
+          },
+          'operatingsystem_support' => {
+            'type' => 'array',
+            'items' => {
+              'properties' => {
+                'operatingsystem' => {
+                  'type' => 'string',
+                },
+                'operatingsystemrelease' => {
+                  'type' => 'array',
+                  'items' => {
+                    'type' => 'string',
+                  },
+                },
+              },
+              'required' => %w[
+                operatingsystem
+              ],
+            },
+          },
+          'name' => {
+            'type' => 'string',
+            'pattern' => '^\w+-[a-z][a-z0-9_]*$',
+          },
+          'project_page' => {
+            'type' => 'string',
+            'format' => 'uri',
+          },
+          # Undocumented but in use: https://tickets.puppetlabs.com/browse/DOCUMENT-387
+          'requirements' => {
+            'type' => 'array',
+            'items' => {
+              'properties' => {
+                'name' => {
+                  'type' => 'string',
+                },
+                'version_requirement' => {
+                  'type' => 'string',
+                },
+              },
+              'required' => %w[
+                name
+              ],
+            },
+          },
+          'source' => {
+            'type' => 'string',
+          },
+          'summary' => {
+            'type' => 'string',
+            'maxLength' => 144,
+          },
+          'tags' => {
+            'type' => 'array',
+            'items' => {
+              'type' => 'string'
+            },
+          },
+          'version' => {
+            'type' => 'string',
+            'format' => 'semver',
+          },
+        },
+        # from https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
+        'required' => %w[
+          author
+          dependencies
+          license
+          name
+          source
+          summary
+          version
+        ],
+      }
+    end
+    # rubocop:enable Style/TrailingCommaInLiteral
+
+    def validate(data, options = {})
+      JSON::Validator.register_format_validator('semver', method(:semver_validator))
+
+      JSON::Validator.fully_validate(schema, data, options.merge(errors_as_objects: true)).map do |error|
+        field = error[:fragment].split('/')[1]
+        field = 'root' if field.nil? || field.empty?
+
+        message = error[:message]
+                  .sub(/ in schema [\w-]+/, '') # remove schema UUID, not needed in output
+                  .sub(%r{'#/}, "'") # remove root #/ prefix from document paths
+                  .sub("property ''", 'file') # call the root #/ node the file
+
+        { field: field, message: message }
+      end
+    end
+
+    private
+
+    def semver_validator(value)
+      SemanticPuppet::Version.parse(value)
+    rescue SemanticPuppet::Version::ValidationFailure => e
+      raise JSON::Schema::CustomFormatError, "must be a valid semantic version: #{e.message}"
+    end
+  end
+end

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
 
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
-  s.add_runtime_dependency 'json'
+  s.add_runtime_dependency 'json-schema', '~> 2.8'
   s.add_runtime_dependency 'semantic_puppet', '>= 0.1.2', '< 2.0.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -1,0 +1,38 @@
+describe MetadataJsonLint::Schema do
+  describe '#schema' do
+    it { expect(subject.schema).to be_a(Hash) }
+  end
+
+  describe '#validate' do
+    let(:minimal) { { author: '', dependencies: [], license: 'A', name: 'a-a', source: '', summary: '', version: '1.0.0' } }
+
+    context 'with empty hash' do
+      subject { described_class.new.validate({}) }
+      it { is_expected.to be_a(Array) }
+      it { expect(subject.size).to eq(7) }
+      it { is_expected.to include(field: 'root', message: "The file did not contain a required property of 'author'") }
+    end
+
+    context 'with minimal entries' do
+      subject { described_class.new.validate(minimal) }
+      it { is_expected.to eq([]) }
+    end
+
+    context 'with validation error on entry' do
+      subject { described_class.new.validate(minimal.merge(summary: 'A' * 145)) }
+      it { is_expected.to eq([{ field: 'summary', message: "The property 'summary' was not of a maximum string length of 144" }]) }
+    end
+
+    context 'with validation error on nested entry' do
+      subject { described_class.new.validate(minimal.merge(dependencies: [{ name: 'in###id' }])) }
+      it { expect(subject.size).to eq(1) }
+      it { is_expected.to include(field: 'dependencies', message: a_string_matching(%r{The property 'dependencies/0/name' value "in###id" did not match the regex})) }
+    end
+
+    context 'with semver validation failure' do
+      subject { described_class.new.validate(minimal.merge(version: 'a')) }
+      it { expect(subject.size).to eq(1) }
+      it { is_expected.to include(field: 'version', message: a_string_matching(/The property 'version' must be a valid semantic version/)) }
+    end
+  end
+end

--- a/tests/long_summary/expected
+++ b/tests/long_summary/expected
@@ -1,1 +1,1 @@
-Field 'summary' exceeds 144 characters in metadata.json
+(ERROR) summary: The property 'summary' was not of a maximum string length of 144

--- a/tests/noname/expected
+++ b/tests/noname/expected
@@ -1,1 +1,1 @@
-Required field 'name' not found in metadata.json.
+(ERROR) required_fields: The file did not contain a required property of 'name'

--- a/tests/tags_no_array/expected
+++ b/tests/tags_no_array/expected
@@ -1,1 +1,1 @@
-Tags must be in an array. Currently it's a String.
+(ERROR) tags: The property 'tags' of type string did not match the following type: array


### PR DESCRIPTION
Validating metadata.json with a JSON schema provides very easy and
reliable type checking, key checking, and basic validation of string
formats and lengths without duplicated code or needing to add lots of
very similar acceptance tests.

It also standardises error responses, using the top-level key name in
the JSON format mode for any errors within that part of the document.

---

Obsoletes #59 and similar changes.

Validated against all VP modules, no new errors logged.