### PR TITLE
Don't log license ID warning with --no-strict-license

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -108,10 +108,9 @@ module MetadataJsonLint
     # Shoulds/recommendations
     # From: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
     #
-    if !parsed['license'].nil? && !SpdxLicenses.exist?(parsed['license']) && parsed['license'] != 'proprietary'
+    if options[:strict_license] && !parsed['license'].nil? && !SpdxLicenses.exist?(parsed['license']) && parsed['license'] != 'proprietary'
       msg = "License identifier #{parsed['license']} is not in the SPDX list: http://spdx.org/licenses/"
-
-      options[:strict_license] == true ? error(:license, msg) : warn(:license, msg)
+      warn(:license, msg)
     end
 
     if !parsed['tags'].nil? && !parsed['tags'].is_a?(Array)

--- a/tests/bad_license/metadata.json
+++ b/tests/bad_license/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 0.0.4"
+      "version_requirement": ">= 0.0.4 <1.0.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/tests/json_format/expected
+++ b/tests/json_format/expected
@@ -1,1 +1,1 @@
-"errors":\[{"check":"license","msg":"License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/"}\]
+"warnings":\[{"check":"license","msg":"License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/"}\]

--- a/tests/json_format/metadata.json
+++ b/tests/json_format/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 0.0.4"
+      "version_requirement": ">= 0.0.4 <1.0.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -98,8 +98,10 @@ test "duplicate-dep" $SUCCESS --no-fail-on-warnings
 
 # Run a broken one, expect FAILURE
 test "bad_license" $FAILURE
-# Run with --no-strict-license, expect SUCCESS
-test "bad_license" $SUCCESS --no-strict-license --no-fail-on-warnings
+# Run with --no-strict-license only, expect SUCCESS
+test "bad_license" $SUCCESS --no-strict-license
+# Run with --no-fail-on-warnings, expect SUCCESS
+test "bad_license" $SUCCESS --no-fail-on-warnings
 
 # Run a broken one, expect FAILURE
 test "long_summary" $FAILURE


### PR DESCRIPTION
Prior to a4bc76e, disabling strict-license would log a warning but not
exit with a failure, but now logging the warning will exit with a
failure status unless fail-on-warnings is also disabled.

This change downgrades license ID failures to warnings all of the time
(since it's a recommendation in the docs anyway) and disables them
entirely when strict-license is disabled, which better reflects what the
flag is useful for - skipping the check.

Now disabling strict-license will not cause a failure exit status and
the default behaviour is still to exit with a failure because of the
warning.

Fixes #69