### PR TITLE
Move exit() calls into CLI, allow rake tasks to keep executing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 Gemfile.lock
 /.bundle
 /vendor
-tests/*/last_output
+tests/*/last_*output

--- a/lib/metadata-json-lint/rake_task.rb
+++ b/lib/metadata-json-lint/rake_task.rb
@@ -5,5 +5,7 @@ require 'json'
 
 desc 'Run metadata-json-lint'
 task :metadata_lint do
-  MetadataJsonLint.parse('metadata.json') if File.exist?('metadata.json')
+  if File.exist?('metadata.json')
+    abort unless MetadataJsonLint.parse('metadata.json')
+  end
 end

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -51,7 +51,7 @@ module MetadataJsonLint
            ARGV[0]
          end
 
-    MetadataJsonLint.parse(mj)
+    exit(MetadataJsonLint.parse(mj) ? 0 : 1)
   end
   module_function :run
 
@@ -131,11 +131,11 @@ module MetadataJsonLint
       end
 
       if !@errors.empty? || (!@warnings.empty? && (options[:fail_on_warnings] == true))
-        exit(1)
+        return false
       end
     end
 
-    exit(0)
+    true
   end
   module_function :parse
 

--- a/tests/rake_chaining/Rakefile
+++ b/tests/rake_chaining/Rakefile
@@ -1,0 +1,7 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'
+
+task :test => %i[metadata_lint success]
+task :success do
+  puts 'Successfully linted'
+end

--- a/tests/rake_chaining/metadata.json
+++ b/tests/rake_chaining/metadata.json
@@ -1,0 +1,91 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "1.2.3"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": "< 1.2.3"
+    },
+    {
+      "name": "puppetlabs/puppetdb",
+      "version_requirement": "<= 1.2.3"
+    },
+    {
+      "name": "puppetlabs/vcsrepo",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs/rabbitmq",
+      "version_requirement": "1.x"
+    },
+    {
+      "name": "puppetlabs/motd",
+      "version_requirement": "1.2.x"
+    }
+  ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -66,7 +66,7 @@ test_rake() {
   local RESULT=-1;
 
   cd $name;
-  bundle exec rake $rake_task >/dev/null 2>&1
+  bundle exec rake $rake_task >last_rake_output 2>&1
   RESULT=$?
   if [ $RESULT -ne $expect ]; then
     fail "Failing Test '${name}' (rake: ${rake_task})"
@@ -153,5 +153,11 @@ test_rake "rake_global_options" $SUCCESS
 
 # Test multiple lints with different options
 test_rake "rake_multiple_json_options" $SUCCESS metadata_lint_multi
+
+# Test successful lint followed by further tasks
+test_rake "rake_chaining" $SUCCESS test
+if ! grep -qx "Successfully linted" rake_chaining/last_rake_output; then
+  fail "Failing Test 'rake_chaining' failed to run second rake task"
+fi
 
 exit $STATUS


### PR DESCRIPTION
On success, no exit(0) call is made from a rake task, allowing execution
to continue to further tasks. exit() calls are now only made when used
in CLI mode.

Fixes #70