### PR TITLE
Keep backwards compatibility to Ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 desc 'Run all tests'
-task :test => %i[rubocop spec test:acceptance]
+task test: %w[rubocop spec test:acceptance]
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -37,8 +37,8 @@ module MetadataJsonLint
         options[:fail_on_warnings] = v
       end
 
-      opts.on('-f', '--format FORMAT', %i[text json], 'The format in which results will be output (text, json)') do |format|
-        options[:format] = format
+      opts.on('-f', '--format FORMAT', %w[text json], 'The format in which results will be output (text, json)') do |format|
+        options[:format] = format.to_sym
       end
     end.parse!
 

--- a/tests/rake_chaining/Rakefile
+++ b/tests/rake_chaining/Rakefile
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
 require 'metadata-json-lint/rake_task'
 
-task :test => %i[metadata_lint success]
+task test: %w[metadata_lint success]
 task :success do
   puts 'Successfully linted'
 end


### PR DESCRIPTION
Rubocop still complains on 1.9, but the code and tests work

fixes #74