### PR TITLE
Specify ruby version dependency explicitly

### DIFF
--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/voxpupuli/metadata-json-lint'
   s.license     = 'Apache-2.0'
 
+  s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
   s.add_runtime_dependency 'json-schema', '~> 2.8'
   s.add_runtime_dependency 'semantic_puppet', '>= 0.1.2', '< 2.0.0'


### PR DESCRIPTION
Addresses the underlying concerns in #74 and #75.