### PR TITLE
Only log open dependency warning with --strict-dependencies

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -164,10 +164,10 @@ module MetadataJsonLint
   def validate_version_requirement!(dep, requirement)
     # Open ended dependency
     # From: https://docs.puppet.com/puppet/latest/reference/modules_metadata.html#best-practice-set-an-upper-bound-for-dependencies
-    if requirement.open_ended?
+    if options[:strict_dependencies] && requirement.open_ended?
       msg = "Dependency #{dep['name']} has an open " \
         "ended dependency version requirement #{dep['version_requirement']}"
-      options[:strict_dependencies] == true ? error(:dependencies, msg) : warn(:dependencies, msg)
+      warn(:dependencies, msg)
     end
 
     # Mixing operator and wildcard version syntax

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -112,15 +112,19 @@ test "mixed_version_syntax" $FAILURE
 # Run one with empty dependencies array, expect SUCCESS
 test "no_dependencies" $SUCCESS
 
-# Run one with open ended dependency, expect SUCCESS
-test "open_ended_dependency" $SUCCESS --no-fail-on-warnings
+# Run one with open ended dependency, expect SUCCESS as strict deps is off by default
+test "open_ended_dependency" $SUCCESS
 # Run one with open ended dependency and --strict-dependencies, expect FAILURE
 test "open_ended_dependency" $FAILURE --strict-dependencies
+# Run one with open ended dependency and --strict-dependencies, but pass on warnings, expect SUCCESS
+test "open_ended_dependency" $SUCCESS --strict-dependencies --no-fail-on-warnings
 
 # Run one with missing version_requirement and --no-strict-dependency, expect SUCCESS
-test "missing_version_requirement" $SUCCESS --no-fail-on-warnings
+test "missing_version_requirement" $SUCCESS
 # Run one with open ended dependency and --strict-dependencies, expect FAILURE
 test "missing_version_requirement" $FAILURE --strict-dependencies
+# Run one with open ended dependency and --strict-dependencies, but pass on warnings, expect SUCCESS
+test "missing_version_requirement" $SUCCESS --strict-dependencies --no-fail-on-warnings
 
 # Run test for "proprietary"-licensed modules, expect SUCCESS
 test "proprietary" $SUCCESS


### PR DESCRIPTION
Same change as 748d23e but for --strict-dependencies, a change in
behaviour since a4bc76e.

Open dependency checks are now opt-in again (when --strict-dependencies
is given), and they're logged as warnings rather than needing users to
also disable fail on warnings.

Fixes #76