### PR TITLE
Add logic to allow for Puppet 5.0.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 /.bundle
 /vendor
 tests/*/last_*output
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.0.0
   - 2.1.9
   - 2.3.1
+  - 2.4.1
 
 deploy:
   provider: rubygems

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-group :test do
-  gem 'semantic_puppet'
-end
-
 gemspec

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ metadata-json-lint is compatible with Ruby versions 2.0.0, 2.1.9, 2.3.1, and 2.4
 ## Installation
 
 Puppet 4.9.0 and newer:
+
 via `gem` command:
 ``` shell
 gem install metadata-json-lint
@@ -19,7 +20,8 @@ via Gemfile:
 gem 'metadata-json-lint'
 ```
 
-Puppet 4.8.x and older:
+**Puppet 4.8.x and older:**
+
 via `gem` command:
 ``` shell
 gem install metadata-json-lint semantic_puppet

--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ The metadata-json-lint tool validates and lints `metadata.json` files in Puppet 
 metadata-json-lint is compatible with Ruby versions 2.0.0, 2.1.9, 2.3.1, and 2.4.1.
 
 ## Installation
-**NOTE: `metadata-json-lint` has a dependency on the `semantic_puppet` gem.
-A conflict within Puppet 5.0.0's vendored `semantic_puppet` renders this gem
-incompatible with Puppet 5.0.0**
 
+Puppet 4.9.0 and newer:
 via `gem` command:
 ``` shell
 gem install metadata-json-lint
@@ -19,6 +17,18 @@ gem install metadata-json-lint
 via Gemfile:
 ``` ruby
 gem 'metadata-json-lint'
+```
+
+Puppet 4.8.x and older:
+via `gem` command:
+``` shell
+gem install metadata-json-lint semantic_puppet
+```
+
+via Gemfile:
+``` ruby
+gem 'metadata-json-lint'
+gem 'semantic_puppet
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ The metadata-json-lint tool validates and lints `metadata.json` files in Puppet 
 metadata-json-lint is compatible with Ruby versions 2.0.0, 2.1.9, 2.3.1, and 2.4.1.
 
 ## Installation
-**NOTE: `metadata-json-lint` has a dependency on the `semantic_puppet` gem if you're on 
-Puppet 4 or earlier. This dependency was removed from the gemspec file due to a conflict 
-in Puppet 5 where the `semantic_puppet` ruby gem conflicts with a version of 
-`semantic_puppet` bundled with the core Puppet 5 code.**
+**NOTE: `metadata-json-lint` has a dependency on the `semantic_puppet` gem.
+A conflict within Puppet 5.0.0's vendored `semantic_puppet` renders this gem
+incompatible with Puppet 5.0.0**
 
-### Puppet 5
 via `gem` command:
 ``` shell
 gem install metadata-json-lint
@@ -21,18 +19,6 @@ gem install metadata-json-lint
 via Gemfile:
 ``` ruby
 gem 'metadata-json-lint'
-```
-
-### Puppet 4 and earlier
-via `gem` command:
-``` shell
-gem install metadata-json-lint semantic_puppet
-```
-
-via Gemfile:
-``` ruby
-gem 'metadata-json-lint'
-gem 'semantic_puppet'
 ```
 
 ## Usage

--- a/lib/metadata-json-lint/version_requirement.rb
+++ b/lib/metadata-json-lint/version_requirement.rb
@@ -1,4 +1,5 @@
 require 'puppet'
+require 'semantic_puppet' unless Puppet.version >= '4.9.0'
 
 module MetadataJsonLint
   # Parses a string module version requirement with semantic_puppet and

--- a/lib/metadata-json-lint/version_requirement.rb
+++ b/lib/metadata-json-lint/version_requirement.rb
@@ -1,4 +1,4 @@
-require 'semantic_puppet'
+require 'puppet'
 
 module MetadataJsonLint
   # Parses a string module version requirement with semantic_puppet and

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -2,7 +2,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'metadata-json-lint'
-  s.version     = '2.0.0'
+  s.version     = '2.0.1'
   s.date        = Date.today.to_s
   s.summary     = 'metadata-json-lint /path/to/metadata.json'
   s.description = 'Utility to verify Puppet metadata.json files'
@@ -19,16 +19,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
   s.add_runtime_dependency 'json-schema', '~> 2.8'
+  s.add_runtime_dependency 'puppet', '>= 4.7.0', '< 6.0.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
-  s.requirements << 'semantic_puppet >= 0.1.2 < 2.0.0'
-  s.post_install_message = <<-EOS
-  -------------------------------------------------------------------
-      If your puppet is <= 4.x, then the semantic_puppet gem MUST
-      be in your Gemfile!!
-
-      On puppet >= 5.x, semantic_puppet will break functionality!
-  -------------------------------------------------------------------
-  EOS
 end

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -23,4 +23,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
+  s.post_install_message = '
+  -------------------------------------------------
+      semantic_puppet must be installed within
+      your Gemfile if you use Puppet <= 4.8.x!!
+  -------------------------------------------------
+  '
 end


### PR DESCRIPTION
metadata-json-lint (naturally) isn't aware of the "vendored" version
of semantic_puppet found in Puppet 5.0.0. As such, the gem requires
the "external" version of semantic_puppet to even function and this
means that metadata-json-lint is not compatible with Puppet 5.0.0

A patch is in the works for Puppet 5.0.x that will allow the vendored
and external versions of semantic_puppet to coexist, but until then
metadata-json-lint is only compatible with Puppet 4.x