### PR TITLE
Fix readme for gemfile usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gem install metadata-json-lint semantic_puppet
 via Gemfile:
 ``` ruby
 gem 'metadata-json-lint'
-gem 'semantic_puppet
+gem 'semantic_puppet'
 ```
 
 ## Usage


### PR DESCRIPTION
A trailing quote was lost in a previous edit.