### PR TITLE
Make SemanticPuppet completely optional and remove dependency on Puppet

### DIFF
--- a/lib/metadata-json-lint/version_requirement.rb
+++ b/lib/metadata-json-lint/version_requirement.rb
@@ -1,13 +1,15 @@
-require 'puppet'
-require 'semantic_puppet' unless Puppet.version >= '4.9.0'
-
 module MetadataJsonLint
   # Parses a string module version requirement with semantic_puppet and
   # provides methods to analyse it for lint warnings
   class VersionRequirement
     def initialize(requirement)
       @requirement = requirement
-      @range = SemanticPuppet::VersionRange.parse(requirement)
+
+      if defined?(SemanticPuppet::VersionRange)
+        @range = SemanticPuppet::VersionRange.parse(requirement)
+      elsif requirement.match(/\A[a-z0-9*.\-^~><=|\t ]*\Z/i).nil?
+        raise ArgumentError, "Unparsable version range: \"#{requirement}\""
+      end
     end
 
     # Whether the range uses a comparison operator (e.g. >=) with a wildcard
@@ -26,7 +28,22 @@ module MetadataJsonLint
     end
 
     def open_ended?
-      @range.end == SemanticPuppet::Version::MAX
+      if range
+        range.end == SemanticPuppet::Version::MAX
+      else
+        # Empty requirement strings are open-ended.
+        return true if requirement.strip.empty?
+
+        # Strip superfluous whitespace.
+        range_set = requirement.gsub(/([><=~^])(?:\s+|\s*v)/, '\1')
+
+        # Split on logical OR
+        ranges = range_set.split(/\s*\|\|\s*/)
+
+        # Returns true if any range includes a '>' but not a corresponding '<'
+        # which should be the only way to declare an open-ended range.
+        ranges.select { |r| r.include?('>') }.any? { |r| !r.include?('<') }
+      end
     end
 
     private

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -2,6 +2,12 @@ require 'json'
 require 'spdx-licenses'
 require 'optparse'
 
+begin
+  require 'semantic_puppet'
+rescue LoadError
+  $stderr.puts('Could not find semantic_puppet gem, falling back to internal functionality. Version checks may be less robust.')
+end
+
 require 'metadata-json-lint/schema'
 require 'metadata-json-lint/version_requirement'
 

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
   s.add_runtime_dependency 'json-schema', '~> 2.8'
-  s.add_runtime_dependency 'puppet', '>= 4.7.0', '< 6.0.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -22,10 +22,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
-  s.post_install_message = '
-  -------------------------------------------------
-      semantic_puppet must be installed within
-      your Gemfile if you use Puppet <= 4.8.x!!
-  -------------------------------------------------
-  '
 end

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -22,4 +22,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
+  s.post_install_message = '
+  ----------------------------------------------------------
+      For the most accurate results, the semantic_puppet
+      gem should be included within your Gemfile if you
+      use Puppet <= 4.8.x
+  ----------------------------------------------------------
+  '
 end


### PR DESCRIPTION
This commit changes the two validations that currently use SemanticPuppet
to only use that library if it is already available on the load path. If
not, it falls back to less robust built-in alternatives that should
still be good enough for 99% of use cases. This should eliminate any
depdendency headaches around various versions of Puppet and SemanticPuppet.