### PR TITLE
Clean leading spaces from post_install_message

### DIFF
--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
       gem should be included within your Gemfile if you
       use Puppet <= 4.8.x
   ----------------------------------------------------------
-  '
+  '.gsub(/^  /, '')
 end


### PR DESCRIPTION
This will improve rendering when installing the gem.