### PR TITLE
Fail on empty range

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'public_suffix', '< 3' if RUBY_VERSION < '2.1'

--- a/lib/metadata-json-lint/version_requirement.rb
+++ b/lib/metadata-json-lint/version_requirement.rb
@@ -7,6 +7,7 @@ module MetadataJsonLint
 
       if defined?(SemanticPuppet::VersionRange)
         @range = SemanticPuppet::VersionRange.parse(requirement)
+        raise ArgumentError, "Range matches no versions: \"#{requirement}\"" if @range == SemanticPuppet::VersionRange::EMPTY_RANGE
       elsif requirement.match(/\A[a-z0-9*.\-^~><=|\t ]*\Z/i).nil?
         raise ArgumentError, "Unparsable version range: \"#{requirement}\""
       end

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -154,6 +154,8 @@ module MetadataJsonLint
       rescue ArgumentError => e
         # Raised when the version_requirement provided could not be parsed
         error :dependencies, "Invalid 'version_requirement' field in metadata.json: #{e}"
+        # Skip to the next dependency
+        next
       end
       validate_version_requirement!(dep, requirement)
 


### PR DESCRIPTION
Fail with a descriptive error when `version_requirement` is in illegal format or matches an empty range.