### PR TITLE
Fail cleanly when requirements is not an array

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -133,6 +133,8 @@ module MetadataJsonLint
   module_function :parse
 
   def validate_requirements!(requirements)
+    return unless requirements.is_a?(Array)
+
     requirements.each do |requirement|
       if requirement['name'] == 'pe'
         warn :requirements, "The 'pe' requirement is no longer supported by the Forge."

--- a/tests/non_array_requirements/Rakefile
+++ b/tests/non_array_requirements/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/non_array_requirements/expected
+++ b/tests/non_array_requirements/expected
@@ -1,0 +1,1 @@
+(ERROR) requirements: The property 'requirements' of type string did not match the following type: array

--- a/tests/non_array_requirements/metadata.json
+++ b/tests/non_array_requirements/metadata.json
@@ -1,0 +1,61 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ],
+  "requirements": "aoeu",
+  "dependencies": []
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -141,6 +141,9 @@ test "tags_no_array" $FAILURE
 # Run with json output format
 test "json_format" $FAILURE --format json
 
+# Run against a metadata.json with a string for the requirements
+test "non_array_requirements" $FAILURE
+
 # Test running without specifying file to parse
 cd perfect
 bundle exec metadata-json-lint


### PR DESCRIPTION
When the requirements field is (for example) a string, the schema
validation picks it up but the problem is never displayed to the user.
Before the errors and warnings are displayed, metadata-json-lint
attempts to iterate through the requirements which causes an exception
to be raised.

Before:
```
$ metadata-json-lint test.json
/home/tsharpe/code/metadata-json-lint/lib/metadata_json_lint.rb:137: in
'validate_requirements!': undefined method 'each' for "aoeu":String
(NoMethodError)
```

After:
```
$ metadata-json-lint test.json
(ERROR) requirements: The property 'requirements' of type string did not
match the following type: array
Errors found in test.json
```