### PR TITLE
Pin Rubocop to 0.50.0

### DIFF
--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json-schema', '~> 2.8'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.50.0'
   s.post_install_message = '
   ----------------------------------------------------------
       For the most accurate results, the semantic_puppet


### PR DESCRIPTION
0.50.0 was the last rubocop version to support 2.0.x as a target ruby
version.