### PR TITLE
Try to use the vendored semantic_puppet before requiring the gem

### DIFF
--- a/lib/metadata-json-lint/semantic_puppet_loader.rb
+++ b/lib/metadata-json-lint/semantic_puppet_loader.rb
@@ -1,0 +1,47 @@
+module MetadataJsonLint
+  # Attempts the various methods of loading SemanticPuppet.
+  module SemanticPuppetLoader
+    def try_load
+      try_load_puppet
+      return if defined?(SemanticPuppet)
+
+      try_load_semantic
+      return if defined?(SemanticPuppet)
+
+      try_load_semantic_puppet
+      return if defined?(SemanticPuppet)
+
+      warn 'Could not find semantic_puppet gem, falling back to internal functionality. Version checks may be less robust.'
+    end
+    module_function :try_load
+
+    # Most modern Puppet versions have SemanticPuppet vendored in the proper
+    # namespace and automatically load it at require time.
+    def try_load_puppet
+      require 'puppet'
+    rescue LoadError
+      nil
+    end
+    module_function :try_load_puppet
+
+    # Older Puppet 4.x versions have SemanticPuppet vendored but under the
+    # Semantic namespace and require it on demand, so we need to load it
+    # ourselves and then alias it to SemanticPuppet for convenience.
+    def try_load_semantic
+      require 'semantic'
+      Kernel.const_set('SemanticPuppet', Semantic)
+    rescue LoadError
+      nil
+    end
+    module_function :try_load_semantic
+
+    # If Puppet is not available or is a version that does not have
+    # SemanticPuppet vendored, try to load the external gem.
+    def try_load_semantic_puppet
+      require 'semantic_puppet'
+    rescue LoadError
+      nil
+    end
+    module_function :try_load_semantic_puppet
+  end
+end

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -2,11 +2,8 @@ require 'json'
 require 'spdx-licenses'
 require 'optparse'
 
-begin
-  require 'semantic_puppet'
-rescue LoadError
-  $stderr.puts('Could not find semantic_puppet gem, falling back to internal functionality. Version checks may be less robust.')
-end
+require 'metadata-json-lint/semantic_puppet_loader'
+MetadataJsonLint::SemanticPuppetLoader.try_load
 
 require 'metadata-json-lint/schema'
 require 'metadata-json-lint/version_requirement'


### PR DESCRIPTION
Currently metadata-json-lint doesn't attempt to use the vendored SemanticPuppet
in Puppet, even if it exists. This PR expands on the loader logic to handle the
different possibilities of require SemanticPuppet/Semantic (depending on the
version of Puppet available).