### PR TITLE
Duplicate testing in requirements list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,4 +26,4 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Metrics/ModuleLength:
-  Max: 175
+  Max: 185

--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -137,6 +137,18 @@ module MetadataJsonLint
   end
   module_function :parse
 
+  def validate_requirements_unique(requirements)
+    names = requirements.map { |x| x['name'] }
+    counts = Hash.new(0)
+
+    names.each { |name| counts[name.downcase] += 1 }
+
+    counts.each do |k, v|
+      error :requirements, "Duplicate entries in the 'requirements' list with the name '#{k}'" if v > 1
+    end
+  end
+  module_function :validate_requirements_unique
+
   def validate_requirements!(requirements)
     return unless requirements.is_a?(Array)
 
@@ -154,6 +166,8 @@ module MetadataJsonLint
 
       validate_puppet_ver!(puppet_req) unless puppet_req.instance_variable_get('@requirement').nil?
     end
+
+    validate_requirements_unique(requirements)
   end
   module_function :validate_requirements!
 

--- a/tests/duplicate-requirement/Rakefile
+++ b/tests/duplicate-requirement/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/duplicate-requirement/expected
+++ b/tests/duplicate-requirement/expected
@@ -1,0 +1,1 @@
+Duplicate entries in the 'requirements' list with the name 'puppet'

--- a/tests/duplicate-requirement/metadata.json
+++ b/tests/duplicate-requirement/metadata.json
@@ -1,0 +1,87 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "5.5.1"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "6.11.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "4.x"
+    },
+    {
+      "name": "puppetlabs/firewall",
+      "version_requirement": ">= 0.0.4"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">=1.1.0 <2.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.1.0 <2.0.0"
+    }
+  ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -147,6 +147,9 @@ test "non_array_requirements" $FAILURE
 # Run against a metadata.json with an unsupported minimum Puppet version for the requirements
 test "requirements_eol_version" $FAILURE --strict-puppet-version
 
+# Run a broken one, expect FAILURE
+test "duplicate-requirement" $FAILURE
+
 # Test running without specifying file to parse
 cd perfect
 bundle exec metadata-json-lint


### PR DESCRIPTION
The names in the requirements list must be
unique otherwise PuppetForge will throw the
following message when trying to upload.

Found multiple entries in the 'requirements' list in metadata.json with
the name 'puppet'. Entries in the 'requirements' list must have unique
'name' values.

See testing for example.