### PR TITLE
Require Ruby 2.1 and drop post_install_message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ language: ruby
 script:
   - bundle exec rake test
 
-sudo: false
-
 rvm:
-  - 2.1.9
-  - 2.4.3
-  - 2.4.4
-  - 2.5.1
+  - 2.1
+  - 2.4
+  - 2.5
+  - 2.6
   - 2.7
 
 deploy:
@@ -20,7 +18,7 @@ deploy:
   gem: metadata-json-lint
   on:
     tags: true
-    rvm: 2.5.1
+    rvm: 2.7
     repo: voxpupuli/metadata-json-lint
 
 notifications:

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -24,11 +24,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'semantic_puppet'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '~> 0.50.0'
-  s.post_install_message = '
-  ----------------------------------------------------------
-      For the most accurate results, the semantic_puppet
-      gem should be included within your Gemfile if you
-      use Puppet <= 4.8.x
-  ----------------------------------------------------------
-  '.gsub(/^  /, '')
 end

--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/voxpupuli/metadata-json-lint'
   s.license     = 'Apache-2.0'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.1.0'
   s.add_runtime_dependency 'spdx-licenses', '~> 1.0'
   s.add_runtime_dependency 'json-schema', '~> 2.8'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Puppet 4 is EOL so there's no real reason to keep showing this message. Nobody should be using Puppet <= 4.8.x anymore.

By keeping Ruby 2.1 support, it is still possible to use Puppet 4.9 and newer.