### PR TITLE
Add test for invalid task metadata

### DIFF
--- a/tests/invalid_escape_char/Rakefile
+++ b/tests/invalid_escape_char/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+require 'metadata-json-lint/rake_task'

--- a/tests/invalid_escape_char/expected
+++ b/tests/invalid_escape_char/expected
@@ -1,0 +1,1 @@
+Error: Unable to parse metadata.json: [0-9]*: unexpected token at

--- a/tests/invalid_escape_char/metadata.json
+++ b/tests/invalid_escape_char/metadata.json
@@ -1,0 +1,6 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "A description with an invalid \( escape sequence",
+  "parameters": {}
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -104,6 +104,9 @@ test "bad_license" $SUCCESS --no-strict-license
 test "bad_license" $SUCCESS --no-fail-on-warnings
 
 # Run a broken one, expect FAILURE
+test "invalid_escape_char" $FAILURE
+
+# Run a broken one, expect FAILURE
 test "long_summary" $FAILURE
 
 # Run a broken one, expect FAILURE


### PR DESCRIPTION
Add test for task metadata file with invalid escape character.
This test is expected to fail on invalid json, but instead it fails on invalid schema - the task metadata files have a different schema. I'm not sure what exactly happens in `pdk validate` when no error is raised on this task metadata json.