### PR TITLE
Lazy load metadata_json_lint

### DIFF
--- a/lib/metadata-json-lint/rake_task.rb
+++ b/lib/metadata-json-lint/rake_task.rb
@@ -1,11 +1,10 @@
 require 'rake'
 require 'rake/tasklib'
-require 'metadata_json_lint'
-require 'json'
 
 desc 'Run metadata-json-lint'
 task :metadata_lint do
   if File.exist?('metadata.json')
+    require 'metadata_json_lint'
     abort unless MetadataJsonLint.parse('metadata.json')
   end
 end


### PR DESCRIPTION
It should not be required to load the whole library just to define the rake task. This prevents pulling in many libraries when a user runs rake -T or an unrelated rake task.