### PR TITLE
gemspec: drop deprecated `date` attribute

### DIFF
--- a/metadata-json-lint.gemspec
+++ b/metadata-json-lint.gemspec
@@ -1,9 +1,6 @@
-require 'date'
-
 Gem::Specification.new do |s|
   s.name        = 'metadata-json-lint'
   s.version     = '3.0.2'
-  s.date        = Date.today.to_s
   s.summary     = 'metadata-json-lint /path/to/metadata.json'
   s.description = 'Utility to verify Puppet metadata.json files'
   s.authors     = ['Vox Pupuli']


### PR DESCRIPTION
cherrypicked from https://github.com/voxpupuli/metadata-json-lint/pull/125/