### PR TITLE
Remove coverage as a vector in the testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - ruby: "2.7"
-          - ruby: "3.0"
-          - ruby: "3.1"
-            coverage: "yes"
-          - ruby: "3.2"
-          - ruby: "3.3"
+        ruby:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
     env:
-      COVERAGE: ${{ matrix.coverage }}
+      COVERAGE: ${{ matrix.ruby == "3.1" && 'yes' }}
       # https://github.com/rubygems/rubygems/issues/5234#issuecomment-1003773622
       RUBYOPT: '--disable-did_you_mean'
     name: RSpec - Ruby ${{ matrix.ruby }}


### PR DESCRIPTION

This simplifies the matrix to just Ruby versions and derive the value for COVERAGE by an expression.

Link: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-     expressions-in-workflows-and-actions#example

Currently I don't know if this works, but it opens the path to using https://github.com/voxpupuli/ruby-   version/.
