### PR TITLE
Fail on escape sequences in metadata.json

### DIFF
--- a/tests/invalid_escape_char/Rakefile
+++ b/tests/invalid_escape_char/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+require 'metadata-json-lint/rake_task'

--- a/tests/invalid_escape_char/expected
+++ b/tests/invalid_escape_char/expected
@@ -1,0 +1,1 @@
+Error: Unable to parse metadata.json: Invalid escape character in string

--- a/tests/invalid_escape_char/metadata.json
+++ b/tests/invalid_escape_char/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "A description with an invalid \( escape sequence",
+  "license": "Apache-2.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+  ],
+  "requirements": [
+  ],
+  "dependencies": [
+  ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -104,6 +104,9 @@ test "bad_license" $SUCCESS --no-strict-license
 test "bad_license" $SUCCESS --no-fail-on-warnings
 
 # Run a broken one, expect FAILURE
+test "invalid_escape_char" $FAILURE
+
+# Run a broken one, expect FAILURE
 test "long_summary" $FAILURE
 
 # Run a broken one, expect FAILURE


### PR DESCRIPTION
This is an enhancement of https://github.com/voxpupuli/metadata-json-lint/pull/120

We now use a regex to identify invalid escape sequences. `JSON.parse()`
has no built-in way to detect this. Even in strict mode it ignores it:

```
irb(main):002> require 'json'
=> true
irb(main):003> JSON.parser = JSON::Ext::Parser
=> JSON::Ext::Parser
irb(main):004> JSON.parse('{"summary": "A description with an invalid \( escape sequence"}')
=> {"summary"=>"A description with an invalid ( escape sequence"}
irb(main):005> JSON.parse("{\"summary\": \"A description with an invalid \( escape sequence\"}")
=> {"summary"=>"A description with an invalid ( escape sequence"}
irb(main):006>
```