### PR TITLE
CI: Switch to voxpupuli/ruby-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,48 +10,45 @@ env:
   BUNDLE_WITHOUT: release
 
 jobs:
-  rubocop:
+  rubocop_and_matrix:
     runs-on: ubuntu-latest
+    outputs:
+      ruby: ${{ steps.ruby.outputs.versions }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Ruby ${{ matrix.ruby }}
+      - name: Install Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: '3.4'
           bundler-cache: true
-      - name: Run Rubocop
+      - name: Run RuboCop
         run: bundle exec rake rubocop
-  rspec:
+      - id: ruby
+        uses: voxpupuli/ruby-version@v1
+
+  test:
+    name: "Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
+    needs: rubocop_and_matrix
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
-          - "3.3"
-          - "3.4"
-    env:
-      # https://github.com/rubygems/rubygems/issues/5234#issuecomment-1003773622
-      RUBYOPT: '--disable-did_you_mean'
-    name: RSpec - Ruby ${{ matrix.ruby }}
+        ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Ruby ${{ matrix.ruby }}
+      - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: spec tests
+      - name: Run tests
         run: bundle exec rake test
-      - name: Verify gem builds
+      - name: Build the gem
         run: gem build --strict --verbose *.gemspec
 
   tests:
     needs:
-      - rubocop
-      - rspec
+      - test
     runs-on: ubuntu-latest
     name: Test suite
     steps:


### PR DESCRIPTION
This now uses the same CI config as puppet_metadata.