### PR TITLE
Create man page for metadata-json-lint binary

### DIFF
--- a/docs/metadata-json-lint.man.1.rst
+++ b/docs/metadata-json-lint.man.1.rst
@@ -1,0 +1,56 @@
+==================
+metadata-json-lint
+==================
+
+-------------------------------------------------------
+Validate and lint metadata.json files in Puppet modules
+-------------------------------------------------------
+
+:Author: Gabriel Filion
+:Date: 2020
+:Manual section: 1
+
+Synopsis
+========
+
+| metadata-json-lint [options] <path>
+
+Description
+===========
+
+The ``metadata-json-lint`` tool validates and lints ``metadata.json`` files in
+Puppet modules against style guidelines from the Puppet Forge module metadata
+recommendations.
+
+The tool can be used as a binary command, or it can be used as a rake task.
+See the project's ``README.md`` file for instructions on how to use the rake
+task.
+
+Options
+=======
+
+| **[no-]strict-dependencies**
+|     Whether to fail if module version dependencies are open-ended. Defaults
+|     to ``false``.
+
+| **[no-]strict-license**
+|     Whether to fail on strict license check. Defaults to `true`.
+
+| **[no-]fail-on-warnings**
+|     Whether to fail on warnings. Defaults to `true`.
+
+| **[no-]strict-puppet-version**
+|     Whether to fail if Puppet version requirements are open-ended or no
+|     longer supported. Defaults to `false`.
+
+Examples
+========
+
+Test a metadata.json file::
+
+        $ metadata-json-lint /path/to/metadata.json
+
+See also
+========
+
+https://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file


### PR DESCRIPTION
This file is currently not taken into account. It can be compiled to a man page with rst2man.

I've written a man page for the `metadata-json-lint` binary when creating a pacakge for this in debian archives. I've used the ReStructuredText format just because I know how to transform that into a man page with `rst2man`, but it could be converted to another format that would suit maintainers better.

This pull request is meant to start discussions about how to format and include such a man page document.

Are you interested in integrating such a man page? If so, is rst an acceptable format? How should I hook it up to a build system to produce the end result?