### PR TITLE
Update test for new json 2.10.0 release

### DIFF
--- a/tests/broken/expected
+++ b/tests/broken/expected
@@ -1,1 +1,1 @@
-Error: Unable to parse metadata.json:.* unexpected token at
+Error: Unable to parse metadata.json: 


### PR DESCRIPTION
json 2.10.0 updated the text in exceptions. This was done in
https://github.com/ruby/json/issues/754. metadata-json-lint prints the
exception and our test verified the exception text. That's no longer
consistent between older and newer json messages.

I think it provides no benefit to match the exception text, so lets
remove it from our test.